### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -18,6 +18,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       digests: ${{ steps.hash.outputs.digests }}

--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,4 +1,6 @@
 name: Jekyll site CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ppraj916110-maker/Tradingekmission-website/security/code-scanning/2](https://github.com/ppraj916110-maker/Tradingekmission-website/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow, specifying the minimum required permissions for the job. Since the workflow only checks out code and builds the site, it does not require any write permissions. The best way to fix this is to add `permissions: contents: read` at the workflow level (above the `jobs:` key), which will apply to all jobs in the workflow unless overridden. This change should be made in the `.github/workflows/jekyll-docker.yml` file, immediately after the `name:` and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
